### PR TITLE
Update to match current best config and simplify the parameterization…

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,8 +7,6 @@ params = {
     'lr_update'       : [1e-3, 1e-4, 1e-3, 1e-4, 1e-4, 1e-5, 1e-5, 1e-6, 1e-7],
     'k_batch'         : 1,
     'n_grad'          : 5,
-    'dim_grad_solver' : 150,
-    'dropout'         : 0.25,
     'dT'              : 5, ## Time window of each space-time patch
     'dx'              : 1,   ## subsampling step if > 1
     'W'               : 200, # width/height of each space-time patch
@@ -22,18 +20,21 @@ params = {
     # stochastic version
     'stochastic'      : False,
 
-    # animation maps 
+    # animation maps 
     'animate'         : False,
 
     # NN architectures and optimization parameters
-    'batch_size'      : 10, #16#4#4#8#12#8#256#
+    'batch_size'      : 2, #16#4#4#8#12#8#256#
     'DimAE'           : 50, #10#10#50
-    'dimGradSolver'   : 100, # dimension of the hidden state of the LSTM cell
+    'dim_grad_solver' : 150,
+    'dropout'         : 0.25,
+    'dropout_phi_r'   : 0.,
 
-    'alpha_MSE'       : 0.1,
-    'alpha_Proj'      : 0.5,
-    'alpha_SR'        : 0.5,
-    'alpha_LR'        : 0.5,  # 1e4
+    'alpha_proj'      : 0.5,
+    'alpha_sr'        : 0.5,
+    'alpha_lr'        : 0.5,  # 1e4
+    'alpha_mse_ssh'   : 10.,
+    'alpha_mse_gssh'  : 1.,
 
     # data generation
     'sigNoise'        : 0.,## additive noise standard deviation
@@ -42,9 +43,6 @@ params = {
     'rnd1'            : 0, ## random seed for patch extraction (space sam)
     'rnd2'            : 100, ## random seed for patch extraction
     'dwscale'         : 1,
-
-    'betaX'           : 42.20436766972647, #None
-    'betagX'          : 77.99700321505073, #None
 
     'UsePriodicBoundary' : False,  # use a periodic boundary for all conv operators in the gradient model (see torch_4DVarNN_dinAE)
     'InterpFlag'         : False, # True :> force reconstructed field to observed data after each gradient-based update

--- a/main.py
+++ b/main.py
@@ -36,38 +36,6 @@ class FourDVarNetRunner:
         w_[int(self.cfg.dT / 2)] = 1.
         self.wLoss = torch.Tensor(w_)
 
-        # recompute the MSE for OI on training dataset
-        # to define weighing parameters in the training
-        if self.cfg.betaX is None or self.cfg.betagX is None:
-            running_loss_GOI = 0.
-            running_loss_OI = 0.
-            num_loss = 0
-
-            gradient_img = gradient_img.to(device)
-            self.wLoss = self.wLoss.to(device)
-
-            for targets_OI, inputs_Mask, targets_GT in dataloaders['train']:
-                targets_OI = targets_OI.to(device)
-                inputs_Mask = inputs_Mask.to(device)
-                targets_GT = targets_GT.to(device)
-
-                # gradient norm field
-                g_targets_GT = gradient_img(targets_GT)
-                loss_OI = NN_4DVar.compute_WeightedLoss(targets_GT - targets_OI, self.wLoss)
-                loss_GOI = NN_4DVar.compute_WeightedLoss(gradient_img(targets_OI) - g_targets_GT, self.wLoss)
-                running_loss_GOI += loss_GOI.item() * targets_GT.size(0)
-                running_loss_OI += loss_OI.item() * targets_GT.size(0)
-                num_loss += targets_GT.size(0)
-
-            epoch_loss_GOI = running_loss_GOI / num_loss
-            epoch_loss_OI = running_loss_OI / num_loss
-
-            betaX = 1. / epoch_loss_OI
-            betagX = 1. / epoch_loss_GOI
-
-            print(".... MSE(Tr) OI %.3f -- MSE(Tr) gOI %.3f " % (epoch_loss_OI, epoch_loss_GOI))
-            print(".... betaX = %.3f -- betagX %.3f " % (betaX, betagX))
-
         if dataloading == "old":
             datamodule = LegacyDataLoading(self.cfg)
         elif dataloading == "with_sst":

--- a/models.py
+++ b/models.py
@@ -121,7 +121,7 @@ class Phi_r(torch.nn.Module):
         x = self.decoder(x)
         if self.stochastic == True:
             W = torch.randn(x.shape).to(device)
-            #  g(W) = alpha(x)*h(W)
+            #  g(W) = alpha(x)*h(W)
             # gW = torch.mul(self.regularize_variance(x),self.correlate_noise(W))
             gW = self.correlate_noise(W)
             # print(stats.describe(gW.detach().cpu().numpy()))
@@ -212,7 +212,7 @@ class LitModel(pl.LightningModule):
         # main model
         self.model = NN_4DVar.Solver_Grad_4DVarNN(
             Phi_r(self.hparams.shapeData[0], self.hparams.DimAE, self.hparams.dW, self.hparams.dW2, self.hparams.sS,
-                  self.hparams.nbBlocks, self.hparams.dropout, self.hparams.stochastic),
+                  self.hparams.nbBlocks, self.hparams.dropout_phi_r, self.hparams.stochastic),
             Model_H(self.hparams.shapeData[0]),
             NN_4DVar.model_GradUpdateLSTM(self.hparams.shapeData, self.hparams.UsePriodicBoundary,
                                           self.hparams.dim_grad_solver, self.hparams.dropout),
@@ -427,9 +427,9 @@ class LitModel(pl.LightningModule):
             loss_LR = NN_4DVar.compute_WeightedLoss(self.model_LR(outputs) - targets_GTLR, self.w_loss)
 
             # total loss
-            loss = self.hparams.alpha_MSE * (self.hparams.betaX * loss_All + self.hparams.betagX * loss_GAll) \
-                   + 0.5 * self.hparams.alpha_Proj * (loss_AE + loss_AE_GT)
-            loss += self.hparams.alpha_LR * loss_LR + self.hparams.alpha_SR * loss_SR
+            loss = self.hparams.alpha_mse_ssh * loss_All + self.hparams.alpha_mse_gssh * loss_GAll
+            loss += 0.5 * self.hparams.alpha_proj * (loss_AE + loss_AE_GT)
+            loss += self.hparams.alpha_lr * loss_LR + self.hparams.alpha_sr * loss_SR
 
             # metrics
             mean_GAll = NN_4DVar.compute_WeightedLoss(g_targets_GT, self.w_loss)
@@ -471,7 +471,7 @@ class LitModelWithSST(LitModel):
         # main model
         self.model = NN_4DVar.Solver_Grad_4DVarNN(
             Phi_r(self.hparams.shapeData[0], self.hparams.DimAE, self.hparams.dW, self.hparams.dW2, self.hparams.sS,
-                  self.hparams.nbBlocks, self.hparams.dropout),
+                  self.hparams.nbBlocks, self.hparams.dropout_phi_r),
             Model_HwithSST(self.hparams.shapeData[0], self.hparams.shapeData[0]),
             NN_4DVar.model_GradUpdateLSTM(self.hparams.shapeData, self.hparams.UsePriodicBoundary,
                                           self.hparams.dim_grad_solver, self.hparams.dropout),
@@ -573,9 +573,9 @@ class LitModelWithSST(LitModel):
             loss_LR = NN_4DVar.compute_WeightedLoss(self.model_LR(outputs) - targets_GTLR, self.w_loss)
 
             # total loss
-            loss = self.hparams.alpha_MSE * (self.hparams.betaX * loss_All + self.hparams.betagX * loss_GAll) \
-                   + 0.5 * self.hparams.alpha_Proj * (loss_AE + loss_AE_GT)
-            loss += self.hparams.alpha_LR * loss_LR + self.hparams.alpha_SR * loss_SR
+            loss = self.hparams.alpha_mse_ssh * loss_All + self.hparams.alpha_mse_gssh * loss_GAll
+            loss += 0.5 * self.hparams.alpha_proj * (loss_AE + loss_AE_GT)
+            loss += self.hparams.alpha_lr * loss_LR + self.hparams.alpha_sr * loss_SR
 
             # metrics
             mean_GAll = NN_4DVar.compute_WeightedLoss(g_targets_GT, self.w_loss)


### PR DESCRIPTION
PR to push "my" current best configuration for SSH mapping. Updates include:
- some updates of the parameters
- specific dropout parameter for phi_r set to 0.
- removal of beta** wieghts in the computation of the loss, replaced by different weights for mse_ssh and mse_gssh (no need to compute on the gradient norm over the training dataset before training)